### PR TITLE
Return null if no match for partial router

### DIFF
--- a/Routing/PropertyPartialRouter.cs
+++ b/Routing/PropertyPartialRouter.cs
@@ -57,9 +57,10 @@ namespace ContentDeliveryExtendedRouting.Routing
                 {
                     segmentContext.SetCustomRouteData(RoutingConstants.RoutedPropertyKey, nextSegment.Next);
                     segmentContext.RemainingPath = nextSegment.Remaining;
+                    return content;
                 }
             }
-            return content;
+            return null;
         }
 
         public PartialRouteData GetPartialVirtualPath(IContent content, string language, RouteValueDictionary routeValues, RequestContext requestContext)


### PR DESCRIPTION
The partial router needs to return null if there is no routing made.
This will enable additional partial routes to be registered after the
PropertyPartialRouter.